### PR TITLE
feat: add support for nth-weekday

### DIFF
--- a/__test__/monthly.spec.ts
+++ b/__test__/monthly.spec.ts
@@ -193,3 +193,34 @@ test('Every Tuesday, every other month, limit 18', () => {
     890143200000, 890748000000, 891352800000,
   ]);
 });
+
+test('Monthly on the second to last Monday of the month for 6 months', () => {
+  const rrule = new RRule(Frequency.Monthly)
+    .setByWeekday([{ weekday: Weekday.Monday, n: -2 }])
+    .setCount(6);
+  const set = new RRuleSet(
+    new Date('1997-09-22T09:00:00-04:00').getTime(),
+    'US/Eastern',
+  ).addRrule(rrule);
+
+  const asString = set.toString();
+  const dates = set.all(8);
+
+  expect(asString).toBe(
+    'DTSTART;TZID=US/Eastern:19970922T090000\nFREQ=monthly;COUNT=6;BYHOUR=9;BYMINUTE=0;BYSECOND=0;BYDAY=-2MO',
+  );
+  expect(dates.map((d) => new Date(d).toISOString())).toEqual([
+    '1997-09-22T13:00:00.000Z',
+    '1997-10-20T13:00:00.000Z',
+    '1997-11-17T14:00:00.000Z',
+    '1997-12-22T14:00:00.000Z',
+    '1998-01-19T14:00:00.000Z',
+    '1998-02-16T14:00:00.000Z',
+  ]);
+});
+
+test('Errors on invalid by-weekday', () => {
+  expect(() =>
+    new RRule(Frequency.Monthly).setByWeekday(['invalid' as any]),
+  ).toThrowError('Value is non of these types `JsNWeekday`, `JsWeekday`');
+});

--- a/__test__/parsing.spec.ts
+++ b/__test__/parsing.spec.ts
@@ -97,9 +97,9 @@ test('Should properly parse weekly individual recurrence rule', () => {
   expect(rule.until).toBe(new Date('1997-12-24T00:00:00Z').getTime());
   expect(rule.weekstart).toBe(Weekday.Sunday);
   expect(rule.byWeekday).toEqual([
-    Weekday.Monday,
-    Weekday.Wednesday,
-    Weekday.Friday,
+    { weekday: Weekday.Monday },
+    { weekday: Weekday.Wednesday },
+    { weekday: Weekday.Friday },
   ]);
 
   const asString = rule.toString();

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,16 @@ export const enum Weekday {
   Saturday = 5,
   Sunday = 6
 }
+export interface NWeekday {
+  /**
+   * If set, this represents the nth occurrence of the weekday.
+   * Otherwise it represents every occurrence of the weekday.
+   *
+   * A negative value represents nth occurrence from the end.
+   */
+  n?: number
+  weekday: Weekday
+}
 export const enum Month {
   January = 0,
   February = 1,
@@ -42,7 +52,7 @@ export class RRule {
   get frequency(): Frequency
   get interval(): number
   get count(): number | null
-  get byWeekday(): Weekday[]
+  get byWeekday(): NWeekday[]
   get byHour(): Array<number>
   get byMinute(): Array<number>
   get bySecond(): Array<number>
@@ -56,7 +66,7 @@ export class RRule {
   toString(): string
   setInterval(interval: number): this
   setCount(count: number): this
-  setByWeekday(weekdays: ReadonlyArray<Weekday>): this
+  setByWeekday(weekdays: readonly Array<NWeekday | Weekday>): this
   setByHour(hours: ReadonlyArray<number>): this
   setByMinute(minutes: ReadonlyArray<number>): this
   setBySecond(seconds: ReadonlyArray<number>): this


### PR DESCRIPTION
closes #43

BREAKING CHANGE: `byWeekday` and `setByWeekday` now have new input and output contracts