### PR TITLE
fix: turn `datetime.toString` into a function

### DIFF
--- a/src/js/rrule_datetime.rs
+++ b/src/js/rrule_datetime.rs
@@ -84,7 +84,7 @@ impl RRuleDateTime {
     nanoseconds / 1_000_000
   }
 
-  #[napi(getter)]
+  #[napi(js_name = "toString")]
   pub fn to_string(&self) -> String {
     self.date_time.to_string()
   }

--- a/tests/datetime.spec.ts
+++ b/tests/datetime.spec.ts
@@ -1,0 +1,32 @@
+import { RRuleDateTime } from '../dist';
+
+test.each([new Date(873205200000), 873205200000])(
+  'Can create an RRuleDateTime from a %s',
+  (input) => {
+    const rruleDateTime = new RRuleDateTime(input, 'US/Eastern');
+
+    expect(rruleDateTime.toDate()).toEqual(new Date(873205200000));
+    expect(rruleDateTime.timestamp).toBe(873205200000);
+    expect(rruleDateTime.timezone.isLocal).toBe(false);
+    expect(rruleDateTime.timezone.name).toBe('US/Eastern');
+    expect(rruleDateTime.year).toBe(1997);
+    expect(rruleDateTime.month).toBe(9);
+    expect(rruleDateTime.day).toBe(2);
+    expect(rruleDateTime.hour).toBe(9);
+    expect(rruleDateTime.minute).toBe(0);
+    expect(rruleDateTime.second).toBe(0);
+    expect(rruleDateTime.millisecond).toBe(0);
+  },
+);
+
+it('Can create a local RRuleDateTime', () => {
+  const rruleDateTime = new RRuleDateTime(873205200000);
+  const props = [];
+  for (const prop in rruleDateTime) {
+    props.push(prop);
+  }
+
+  expect(rruleDateTime.timestamp).toBe(873205200000);
+  expect(rruleDateTime.timezone.isLocal).toBe(true);
+  expect(rruleDateTime.timezone.name).toBe('Local');
+});

--- a/tests/datetime.spec.ts
+++ b/tests/datetime.spec.ts
@@ -5,6 +5,7 @@ test.each([new Date(873205200000), 873205200000])(
   (input) => {
     const rruleDateTime = new RRuleDateTime(input, 'US/Eastern');
 
+    expect(rruleDateTime.toString()).toBe('1997-09-02 09:00:00 EDT');
     expect(rruleDateTime.toDate()).toEqual(new Date(873205200000));
     expect(rruleDateTime.timestamp).toBe(873205200000);
     expect(rruleDateTime.timezone.isLocal).toBe(false);


### PR DESCRIPTION
This should be a function instead of a property