### PR TITLE
feat: add `set_from_string`

### DIFF
--- a/__test__/parsing.spec.ts
+++ b/__test__/parsing.spec.ts
@@ -1,4 +1,4 @@
-import { Frequency, Weekday, RRule, RRuleSet } from '../';
+import { Frequency, Weekday, RRule, RRuleSet, RRuleDateTime } from '../';
 
 test('Should properly parse weekly recurrence', () => {
   const set = RRuleSet.parse(
@@ -167,5 +167,18 @@ test('Should throw error on invalid individual recurrence rule until', () => {
 test('Should throw error on invalid individual recurrence rule week start', () => {
   expect(() => RRule.parse('FREQ=DAILY;WKST=Invalid')).toThrowError(
     'RRule parsing error: `Invalid` is not a valid weekday start. Valid values are `MO`, `TU`, `WE`, `TH`, `FR`, `SA` and `SU`.',
+  );
+});
+
+test('Should be able to parse rule set without dtstart', () => {
+  const set = new RRuleSet(
+    new RRuleDateTime(new Date('1997-09-02T09:00:00-04:00'), 'US/Eastern'),
+  );
+  set.setFromString(
+    'RRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=19971224T000000Z;WKST=SU;BYDAY=MO,WE,FR',
+  );
+  const asString = set.toString();
+  expect(asString).toBe(
+    'DTSTART;TZID=US/Eastern:19970902T090000\nRRULE:FREQ=WEEKLY;UNTIL=19971224T000000Z;INTERVAL=2;WKST=Sun;BYHOUR=9;BYMINUTE=0;BYSECOND=0;BYDAY=MO,WE,FR',
   );
 });

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,6 +94,7 @@ export class RRuleDateTime {
 }
 export class RRuleSet {
   constructor(dtstart: RRuleDateTime | Date)
+  setFromString(str: string): this
   static parse(str: string): RRuleSet
   toString(): string
   addRrule(jsRrule: RRule): this

--- a/src/js/rrule_set.rs
+++ b/src/js/rrule_set.rs
@@ -22,6 +22,17 @@ impl RRuleSet {
     Ok(RRuleSet { rrule_set })
   }
 
+  #[napi]
+  pub fn set_from_string(&mut self, str: String) -> napi::Result<&Self> {
+    let cloned = self
+      .rrule_set
+      .clone()
+      .set_from_string(&str)
+      .map_err(|e| napi::Error::new(napi::Status::GenericFailure, e))?;
+    *self = RRuleSet { rrule_set: cloned };
+    Ok(self)
+  }
+
   #[napi(factory, ts_return_type = "RRuleSet")]
   pub fn parse(str: String) -> napi::Result<Self> {
     let rrule_set: rrule::RRuleSet = str


### PR DESCRIPTION
This allows creating an RRuleSet without a DTSTART (see https://github.com/fmeringdal/rust-rrule/pull/105)