### PR TITLE
fix: handle folded or gapped dates

### DIFF
--- a/tests/unit/recurrence/daily.spec.ts
+++ b/tests/unit/recurrence/daily.spec.ts
@@ -272,4 +272,80 @@ describe('Daily', () => {
     expect(set.exrules).toEqualPlain([]);
     expect([...set]).toEqualPlain(dates);
   });
+
+  describe('folds and gaps', () => {
+    it('daily for 10 occurrences across ST => DST', () => {
+      const rrule = new RRule(Frequency.Daily).setCount(10);
+
+      const set = new RRuleSet(
+        new DtStart(DateTime.local(2025, 3, 8, 2, 0, 0), 'US/Pacific'),
+      ).addRRule(rrule);
+
+      expect(set.toString()).toBe(
+        'DTSTART;TZID=US/Pacific:20250308T020000\nRRULE:FREQ=DAILY;COUNT=10',
+      );
+
+      const all = set.all();
+      expect(all).toEqualPlain([
+        DateTime.create(2025, 3, 8, 2, 0, 0, false),
+        DateTime.create(2025, 3, 9, 3, 0, 0, false),
+        DateTime.create(2025, 3, 10, 2, 0, 0, false),
+        DateTime.create(2025, 3, 11, 2, 0, 0, false),
+        DateTime.create(2025, 3, 12, 2, 0, 0, false),
+        DateTime.create(2025, 3, 13, 2, 0, 0, false),
+        DateTime.create(2025, 3, 14, 2, 0, 0, false),
+        DateTime.create(2025, 3, 15, 2, 0, 0, false),
+        DateTime.create(2025, 3, 16, 2, 0, 0, false),
+        DateTime.create(2025, 3, 17, 2, 0, 0, false),
+      ]);
+
+      const between = set.between(
+        DateTime.local(2025, 3, 9, 2, 0, 0),
+        DateTime.local(2025, 3, 11, 2, 0, 0),
+        true,
+      );
+      expect(between).toEqualPlain([
+        DateTime.create(2025, 3, 9, 3, 0, 0, false),
+        DateTime.create(2025, 3, 10, 2, 0, 0, false),
+        DateTime.create(2025, 3, 11, 2, 0, 0, false),
+      ]);
+    });
+
+    it('daily for 10 occurrences across DST => ST', () => {
+      const rrule = new RRule(Frequency.Daily).setCount(10);
+
+      const set = new RRuleSet(
+        new DtStart(DateTime.local(2025, 11, 1, 1, 0, 0), 'US/Pacific'),
+      ).addRRule(rrule);
+
+      expect(set.toString()).toBe(
+        'DTSTART;TZID=US/Pacific:20251101T010000\nRRULE:FREQ=DAILY;COUNT=10',
+      );
+
+      const all = set.all();
+      expect(all).toEqualPlain([
+        DateTime.create(2025, 11, 1, 1, 0, 0, false),
+        DateTime.create(2025, 11, 2, 1, 0, 0, false),
+        DateTime.create(2025, 11, 3, 1, 0, 0, false),
+        DateTime.create(2025, 11, 4, 1, 0, 0, false),
+        DateTime.create(2025, 11, 5, 1, 0, 0, false),
+        DateTime.create(2025, 11, 6, 1, 0, 0, false),
+        DateTime.create(2025, 11, 7, 1, 0, 0, false),
+        DateTime.create(2025, 11, 8, 1, 0, 0, false),
+        DateTime.create(2025, 11, 9, 1, 0, 0, false),
+        DateTime.create(2025, 11, 10, 1, 0, 0, false),
+      ]);
+
+      const between = set.between(
+        DateTime.local(2025, 11, 2, 1, 0, 0),
+        DateTime.local(2025, 11, 4, 1, 0, 0),
+        true,
+      );
+      expect(between).toEqualPlain([
+        DateTime.create(2025, 11, 2, 1, 0, 0, false),
+        DateTime.create(2025, 11, 3, 1, 0, 0, false),
+        DateTime.create(2025, 11, 4, 1, 0, 0, false),
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Resolves #698

https://github.com/lsndr/rrule-rust/blob/5b6042b34c9c46470f94f7c797b343489006350b/lib/rrule/datetime.rs#L38-L41

errors out when dealing with ambiguous folded or gapped dates due to how [`chrono`](https://docs.rs/chrono/latest/chrono/offset/type.MappedLocalTime.html#variant.Single) handles them, causing `between()` calls to error out with `Invalid datetime: ...`

This change should match how [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date#description) handles folds and gaps, choosing the earliest option for folds and moving forward on gaps.

> When attempting to set the local time to a time falling within an offset transition (usually daylight saving time), the exact time is derived using the same behavior as Temporal's [disambiguation: "compatible"](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal/ZonedDateTime#ambiguity_and_gaps_from_local_time_to_utc_time) option. That is, if the local time corresponds to two instants, the earlier one is chosen; if the local time does not exist (there is a gap), we go forward by the gap duration.

Inspiration from https://github.com/typedb/typedb/pull/7329 and https://github.com/chronotope/chrono-tz/pull/188

